### PR TITLE
Don't set `editor.formatOnSave`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "editor.formatOnSave": true,
   "xo.enable": true,
   "xo.format.enable": true,
   "[javascript]": {


### PR DESCRIPTION
I noticed that the setting overrides what the user has locally.